### PR TITLE
Scope artifact uploads under a team directory

### DIFF
--- a/lib/turbo/storage/local_file_store.ex
+++ b/lib/turbo/storage/local_file_store.ex
@@ -70,5 +70,17 @@ defmodule Turbo.Storage.LocalFileStore do
     end
 
     Path.join(upload_dir(), filename)
+    |> Path.dirname()
+    |> case do
+      "." ->
+        Path.join(upload_dir(), filename)
+
+      path ->
+        if not File.exists?(path) do
+          File.mkdir_p(path)
+        end
+
+        Path.join(upload_dir(), filename)
+    end
   end
 end

--- a/lib/turbo_web/controllers/artifact_controller.ex
+++ b/lib/turbo_web/controllers/artifact_controller.ex
@@ -19,7 +19,7 @@ defmodule TurboWeb.ArtifactController do
 
     if team.name != team_name do
       conn
-      |> send_json_resp(404, %{error: "artifact not found"})
+      |> send_json_resp(401, %{error: "team token mismatch"})
     else
       {:ok, body_data, conn} = read_body(conn, length: @max_length)
       {:ok, artifact} = Artifacts.create(body_data, hash, team)

--- a/priv/repo/migrations/20220912185718_artifact_hash_team_constraint.exs
+++ b/priv/repo/migrations/20220912185718_artifact_hash_team_constraint.exs
@@ -1,0 +1,8 @@
+defmodule Turbo.Repo.Migrations.ArtifactHashTeamConstraint do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:artifacts, [:hash])
+    create unique_index(:artifacts, [:hash, :team_id])
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -67,17 +67,17 @@ defmodule TurboWeb.ConnCase do
       setup :register_and_log_in_user
 
   It stores an updated connection, a team and a Bearer token
-  as part of the headers for artifacts authentcation.
+  as part of the headers for artifacts authentication.
   """
-  def create_and_log_in_team(%{conn: conn}) do
+  def create_and_log_in_team(%{conn: conn}, team_name \\ "turbo-racer") do
     user = Turbo.AccountsFixtures.user_fixture()
-    {team, token} = Turbo.TeamsFixtures.team_and_token_fixtures(user, %{name: "turbo-racer"})
+    {team, token} = Turbo.TeamsFixtures.team_and_token_fixtures(user, %{name: team_name})
 
     conn =
       conn
       |> Plug.Conn.assign(:team, team)
       |> Plug.Conn.put_req_header("authorization", "Bearer " <> token.token)
 
-    %{conn: conn, team: team, token: token}
+    %{conn: conn, team: team, token: token, user: user}
   end
 end

--- a/test/support/fixtures/artifacts_fixtures.ex
+++ b/test/support/fixtures/artifacts_fixtures.ex
@@ -32,11 +32,11 @@ defmodule Turbo.ArtifactsFixtures do
     |> Repo.update!()
   end
 
-  def clean_up_artifact(hash) do
-    {:ok, _} = Artifacts.delete(hash)
+  def clean_up_artifact(hash, team_id) do
+    {:ok, _} = Artifacts.delete(hash, team_id)
   end
 
-  def maybe_clean_up_artifact(hash) do
-    Artifacts.delete(hash)
+  def maybe_clean_up_artifact(hash, team_id) do
+    Artifacts.delete(hash, team_id)
   end
 end

--- a/test/turbo/worker/artifact_busting_test.exs
+++ b/test/turbo/worker/artifact_busting_test.exs
@@ -19,8 +19,8 @@ defmodule Turbo.Worker.ArtifactBustingTest do
     # Just make sure that even if the test fails, the artifact will be cleaned-up.
     # In case it has been deleted successfully during the tests, we can safely ignore.
     on_exit(fn ->
-      Turbo.ArtifactsFixtures.maybe_clean_up_artifact(old_artifact.hash)
-      Turbo.ArtifactsFixtures.maybe_clean_up_artifact(new_artifact.hash)
+      Turbo.ArtifactsFixtures.maybe_clean_up_artifact(old_artifact.hash, old_artifact.team_id)
+      Turbo.ArtifactsFixtures.maybe_clean_up_artifact(new_artifact.hash, new_artifact.team_id)
     end)
 
     %{

--- a/test/turbo_web/controllers/artifact_controller_test.exs
+++ b/test/turbo_web/controllers/artifact_controller_test.exs
@@ -31,6 +31,24 @@ defmodule TurboWeb.ArtifactControllerTest do
       ArtifactsFixtures.clean_up_artifact(hash, team.id)
     end
 
+    test "should allow artifact upload with existing hash from other team", %{
+      artifact: artifact,
+      conn: conn
+    } do
+      %{conn: new_conn, team: team} =
+        TurboWeb.ConnCase.create_and_log_in_team(%{conn: conn}, "new-team")
+
+      hash = artifact.hash
+
+      new_conn =
+        new_conn
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put("/v8/artifacts/#{hash}?slug=#{team.name}", "some_binary_data")
+
+      assert %{"filename" => ^hash} = json_response(new_conn, 201)
+      ArtifactsFixtures.clean_up_artifact(hash, team.id)
+    end
+
     test "return unauthorized if Bearer token isn't present" do
       conn =
         build_conn()

--- a/test/turbo_web/controllers/artifact_controller_test.exs
+++ b/test/turbo_web/controllers/artifact_controller_test.exs
@@ -12,7 +12,7 @@ defmodule TurboWeb.ArtifactControllerTest do
     artifact = ArtifactsFixtures.artifact_fixture(hash, context.team)
 
     on_exit(fn ->
-      ArtifactsFixtures.clean_up_artifact(hash)
+      ArtifactsFixtures.clean_up_artifact(hash, context.team.id)
     end)
 
     {:ok, %{artifact: artifact}}
@@ -28,7 +28,7 @@ defmodule TurboWeb.ArtifactControllerTest do
         |> put("/v8/artifacts/#{hash}?slug=#{team.name}", "some_binary_data")
 
       assert %{"filename" => ^hash} = json_response(conn, 201)
-      ArtifactsFixtures.clean_up_artifact(hash)
+      ArtifactsFixtures.clean_up_artifact(hash, team.id)
     end
 
     test "return unauthorized if Bearer token isn't present" do


### PR DESCRIPTION
This change makes sure that in the eventual case where different teams work in the same codebase don't have conflicts when generating the same hash.

In the eventual hash collision, the `team_<id>/` directory will make sure that different teams don't interfere with each other.