### PR TITLE
Health check endpoint

### DIFF
--- a/lib/turbo_web/controllers/health_check_controller.ex
+++ b/lib/turbo_web/controllers/health_check_controller.ex
@@ -1,0 +1,15 @@
+defmodule TurboWeb.HealthCheckController do
+  use TurboWeb, :controller
+
+  alias Turbo.Settings.SettingsContext
+
+  def index(conn, _params) do
+    # Just force a dummy DB query/cache read.
+    # If that doesn't crash, we can assume the system is up
+    _ = SettingsContext.get_app_access()
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode!(%{status: "ok"}))
+  end
+end

--- a/lib/turbo_web/router.ex
+++ b/lib/turbo_web/router.ex
@@ -102,10 +102,15 @@ defmodule TurboWeb.Router do
     put "/settings/access", AppAccessController, :update
   end
 
+  # Telemetry/Operations endpoints (Behind Admin auth)
   scope "/ops", TurboWeb do
     pipe_through [:browser, :require_authenticated_user, :require_admin]
-    # Enables LiveDashboard (Behind Admin auth)
     live_dashboard "/dashboard", metrics: TurboWeb.Telemetry
+  end
+
+  # Health check endpoints
+  scope "/management", TurboWeb do
+    get "/health", HealthCheckController, :index
   end
 
   # Enables the Swoosh mailbox preview in development.

--- a/test/turbo_web/controllers/health_check_controller_test.exs
+++ b/test/turbo_web/controllers/health_check_controller_test.exs
@@ -1,0 +1,10 @@
+defmodule TurboWeb.HealthCheckControllerTest do
+  use TurboWeb.ConnCase
+
+  describe("GET /management/health") do
+    test "Should report healthy when database is available", %{conn: conn} do
+      conn = get(conn, "/management/health")
+      assert %{"status" => "ok"} = json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
A Health check endpoint is usually necessary when deploying to systems using K8S or similar where the container is checked for readiness before registering it to the available servers' pool.

This PR adds `/management/health` and it returns `200` if the DB is responding correctly.