### PR TITLE
User management UI for admins

### DIFF
--- a/lib/turbo/accounts.ex
+++ b/lib/turbo/accounts.ex
@@ -415,6 +415,19 @@ defmodule Turbo.Accounts do
     end
   end
 
+  @spec update_user_role(String.t() | integer(), String.t()) :: Turbo.result(User.t())
+  def update_user_role(user_id, role) do
+    case Repo.get(User, user_id) do
+      nil ->
+        {:error, "User not found"}
+
+      user ->
+        user
+        |> User.role_changeset(%{role: role})
+        |> Repo.update()
+    end
+  end
+
   @doc """
   Toggle user access to the system
   """

--- a/lib/turbo/accounts.ex
+++ b/lib/turbo/accounts.ex
@@ -422,9 +422,20 @@ defmodule Turbo.Accounts do
         {:error, "User not found"}
 
       user ->
-        user
-        |> User.role_changeset(%{role: role})
-        |> Repo.update()
+        maybe_update_role(user, role)
+    end
+  end
+
+  defp maybe_update_role(user, role) do
+    user
+    |> User.role_changeset(%{role: role})
+    |> Repo.update()
+    |> case do
+      {:ok, user} ->
+        {:ok, user}
+
+      {:error, _changeset} ->
+        {:error, "Could not update user role"}
     end
   end
 

--- a/lib/turbo/accounts.ex
+++ b/lib/turbo/accounts.ex
@@ -62,6 +62,14 @@ defmodule Turbo.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
+  @doc """
+  Get a list of all users
+  """
+  @spec get_all_users() :: list(User.t())
+  def get_all_users() do
+    Repo.all(User)
+  end
+
   ## User registration
 
   @doc """

--- a/lib/turbo/accounts/user.ex
+++ b/lib/turbo/accounts/user.ex
@@ -9,6 +9,7 @@ defmodule Turbo.Accounts.User do
     field :confirmed_at, :naive_datetime
     # Role is either "admin" or "user". "user" is the default
     field :role, :string
+    field :is_locked, :boolean
 
     timestamps()
   end
@@ -19,6 +20,7 @@ defmodule Turbo.Accounts.User do
           hashed_password: String.t(),
           confirmed_at: NaiveDateTime.t(),
           role: String.t(),
+          is_locked: boolean(),
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }
@@ -50,6 +52,14 @@ defmodule Turbo.Accounts.User do
   def admin_changeset(user, attrs, opts \\ []) do
     registration_changeset(user, attrs, opts)
     |> put_change(:role, "admin")
+  end
+
+  @doc """
+  Changeset for locking/unlocking user accounts
+  """
+  def lock_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:is_locked])
   end
 
   defp validate_email(changeset) do

--- a/lib/turbo/accounts/user.ex
+++ b/lib/turbo/accounts/user.ex
@@ -54,6 +54,18 @@ defmodule Turbo.Accounts.User do
     |> put_change(:role, "admin")
   end
 
+  def role_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:role])
+    |> validate_inclusion(:role, available_roles())
+  end
+
+  @doc """
+  Available roles for any given user using the system
+  """
+  @spec available_roles() :: list(String.t())
+  def available_roles(), do: ["admin", "user"]
+
   @doc """
   Changeset for locking/unlocking user accounts
   """

--- a/lib/turbo_web/controllers/admin/app_access_controller.ex
+++ b/lib/turbo_web/controllers/admin/app_access_controller.ex
@@ -1,7 +1,6 @@
 defmodule TurboWeb.Admin.AppAccessController do
   use TurboWeb, :controller
   alias Turbo.Settings.SettingsContext
-  require Logger
 
   plug :put_layout, "admin/layout.html"
 

--- a/lib/turbo_web/controllers/admin/user_management_controller.ex
+++ b/lib/turbo_web/controllers/admin/user_management_controller.ex
@@ -11,11 +11,32 @@ defmodule TurboWeb.Admin.UserManagementController do
   end
 
   def toggle_access(conn, %{"user_id" => user_id}) do
-    Logger.info("User toggle: #{user_id}")
+    current_user = conn.assigns[:current_user]
 
+    int_user_id = if is_binary(user_id), do: String.to_integer(user_id), else: user_id
+
+    if int_user_id == current_user.id do
+      halt_current_user_lock(conn)
+    else
+      toggle_user_access(conn, current_user, user_id)
+    end
+  end
+
+  def update_role(conn, _params) do
+    conn
+    |> put_flash(:info, "User role updated.")
+    |> redirect(to: Routes.user_management_path(conn, :index))
+  end
+
+  # This smells a bit. Would be better to have lock and unlock functions
+  # that are distinctively separated from each other.
+  # But this is simple enough for now.
+  defp toggle_user_access(conn, admin_user, user_id) do
     case Accounts.toggle_access(user_id) do
       {:ok, user} ->
         status = if user.is_locked, do: "access revoked", else: "access granted"
+
+        Logger.info("User #{user.id} got its #{status} by admin #{admin_user.id}")
 
         conn
         |> put_flash(:info, "User #{user.email} #{status}.")
@@ -28,9 +49,12 @@ defmodule TurboWeb.Admin.UserManagementController do
     end
   end
 
-  def update_role(conn, _params) do
+  defp halt_current_user_lock(conn) do
     conn
-    |> put_flash(:info, "User role updated.")
+    |> put_flash(
+      :error,
+      "To avoid lockouts, you cannot update your own account. Please contact another admin."
+    )
     |> redirect(to: Routes.user_management_path(conn, :index))
   end
 end

--- a/lib/turbo_web/controllers/admin/user_management_controller.ex
+++ b/lib/turbo_web/controllers/admin/user_management_controller.ex
@@ -32,11 +32,9 @@ defmodule TurboWeb.Admin.UserManagementController do
         |> put_flash(:info, "#{user.email} role updated.")
         |> redirect(to: Routes.user_management_path(conn, :index))
 
-      {:error, changeset} ->
-        Logger.error("Could not update user #{user_id} role: #{inspect(changeset.errors)}")
-
+      {:error, error} ->
         conn
-        |> put_flash(:error, "Could not update user. Please try again.")
+        |> put_flash(:error, error)
         |> redirect(to: Routes.user_management_path(conn, :index))
     end
   end

--- a/lib/turbo_web/controllers/admin/user_management_controller.ex
+++ b/lib/turbo_web/controllers/admin/user_management_controller.ex
@@ -1,0 +1,25 @@
+defmodule TurboWeb.Admin.UserManagementController do
+  use TurboWeb, :controller
+  require Logger
+
+  plug :put_layout, "admin/layout.html"
+
+  def index(conn, _params) do
+    users = Turbo.Accounts.get_all_users()
+    render(conn, "index.html", users: users)
+  end
+
+  def toggle_access(conn, %{"user_id" => user_id}) do
+    Logger.info("User toggle: #{user_id}")
+
+    conn
+    |> put_flash(:info, "User access updated.")
+    |> redirect(to: Routes.user_management_path(conn, :index))
+  end
+
+  def update_role(conn, _params) do
+    conn
+    |> put_flash(:info, "User role updated.")
+    |> redirect(to: Routes.user_management_path(conn, :index))
+  end
+end

--- a/lib/turbo_web/controllers/admin/user_management_controller.ex
+++ b/lib/turbo_web/controllers/admin/user_management_controller.ex
@@ -1,5 +1,6 @@
 defmodule TurboWeb.Admin.UserManagementController do
   use TurboWeb, :controller
+  alias Turbo.Accounts
   require Logger
 
   plug :put_layout, "admin/layout.html"
@@ -12,9 +13,19 @@ defmodule TurboWeb.Admin.UserManagementController do
   def toggle_access(conn, %{"user_id" => user_id}) do
     Logger.info("User toggle: #{user_id}")
 
-    conn
-    |> put_flash(:info, "User access updated.")
-    |> redirect(to: Routes.user_management_path(conn, :index))
+    case Accounts.toggle_access(user_id) do
+      {:ok, user} ->
+        status = if user.is_locked, do: "access revoked", else: "access granted"
+
+        conn
+        |> put_flash(:info, "User #{user.email} #{status}.")
+        |> redirect(to: Routes.user_management_path(conn, :index))
+
+      {:error, error} ->
+        conn
+        |> put_flash(:error, error)
+        |> redirect(to: Routes.user_management_path(conn, :index))
+    end
   end
 
   def update_role(conn, _params) do

--- a/lib/turbo_web/controllers/user_session_controller.ex
+++ b/lib/turbo_web/controllers/user_session_controller.ex
@@ -12,7 +12,9 @@ defmodule TurboWeb.UserSessionController do
   def create(conn, %{"user" => user_params}) do
     %{"email" => email, "password" => password} = user_params
 
-    if user = Accounts.get_user_by_email_and_password(email, password) do
+    user = Accounts.get_user_by_email_and_password(email, password)
+
+    if user && !user.is_locked do
       UserAuth.log_in_user(conn, user, user_params)
     else
       # In order to prevent user enumeration attacks, don't disclose whether the email is registered.

--- a/lib/turbo_web/router.ex
+++ b/lib/turbo_web/router.ex
@@ -100,6 +100,10 @@ defmodule TurboWeb.Router do
 
     get "/settings/access", AppAccessController, :index
     put "/settings/access", AppAccessController, :update
+
+    get "/settings/users", UserManagementController, :index
+    post "/settings/users/access", UserManagementController, :toggle_access
+    post "/settings/users/role", UserManagementController, :update_role
   end
 
   # Telemetry/Operations endpoints (Behind Admin auth)

--- a/lib/turbo_web/templates/admin/user_management/index.html.heex
+++ b/lib/turbo_web/templates/admin/user_management/index.html.heex
@@ -1,0 +1,50 @@
+<%= for user <- @users do %>
+  <div class="p-6 mb-8 bg-white border border-gray-200 divide-y rounded-lg shadow-md">
+    <div class="py-4">
+      <a href="#">
+        <h2 class="mb-2 text-2xl font-bold tracking-tight">
+          <%= user.email %>
+        </h2>
+      </a>
+      <p class="mb-3 font-normal text-gray-700">
+        Account created at <%= user.inserted_at %>
+      </p>
+      <div class="py-2">
+        <div>
+          <.form let={f} for={@conn} action={Routes.user_management_path(@conn, :update_role)}>
+            <%= hidden_input(f, :user_id, value: user.id) %>
+            <%= label(f, :role, "System role",
+              class: "block mb-2 text-sm font-medium text-gray-900"
+            ) %>
+            <%= select(
+              f,
+              :role,
+              [
+                [key: "Admin", value: "admin", selected: user.role == "admin"],
+                [key: "User", value: "user", selected: user.role == "user"]
+              ],
+              class:
+                "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+            ) %>
+            <%= submit("Update role", class: "mt-4 btn-primary") %>
+          </.form>
+        </div>
+      </div>
+    </div>
+    <div class="py-4">
+      <.form let={f} for={@conn} action={Routes.user_management_path(@conn, :toggle_access)}>
+        <%= hidden_input(f, :user_id, value: user.id) %>
+        <span class="block mb-2 text-sm font-medium text-gray-900">Account Management</span>
+
+        <%= if user.is_locked do %>
+          <%= submit("Unlock account", class: "mt-4 btn-primary") %>
+        <% else %>
+          <%= submit("Lock account", class: "mt-4 btn-danger") %>
+        <% end %>
+        <span class="block mt-4 text-xs text-slate-400">
+          Locked accounts lose all their valid sessions to the Turbo Repo Web UI and won't be able to login anymore. This action can be reverted.
+        </span>
+      </.form>
+    </div>
+  </div>
+<% end %>

--- a/lib/turbo_web/templates/admin/user_management/index.html.heex
+++ b/lib/turbo_web/templates/admin/user_management/index.html.heex
@@ -42,7 +42,7 @@
           <%= submit("Lock account", class: "mt-4 btn-danger") %>
         <% end %>
         <span class="block mt-4 text-xs text-slate-400">
-          Locked accounts lose all their valid sessions to the Turbo Repo Web UI and won't be able to login anymore. This action can be reverted.
+          Locked accounts lose all their valid sessions to the Turbo Racer Web UI and won't be able to login anymore. This action can be reverted.
         </span>
       </.form>
     </div>

--- a/lib/turbo_web/templates/admin/user_management/index.html.heex
+++ b/lib/turbo_web/templates/admin/user_management/index.html.heex
@@ -19,10 +19,9 @@
             <%= select(
               f,
               :role,
-              [
-                [key: "Admin", value: "admin", selected: user.role == "admin"],
-                [key: "User", value: "user", selected: user.role == "user"]
-              ],
+              Enum.map(@available_roles, fn role ->
+                [key: role, value: role, selected: user.role == role]
+              end),
               class:
                 "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
             ) %>

--- a/lib/turbo_web/templates/layout/admin/menu.html.heex
+++ b/lib/turbo_web/templates/layout/admin/menu.html.heex
@@ -7,6 +7,12 @@
     ) %>
 
     <%= render("admin/menu_item.html",
+      text: "Users",
+      path: Routes.user_management_path(@conn, :index),
+      conn: @conn
+    ) %>
+
+    <%= render("admin/menu_item.html",
       text: "Live Dashboard",
       path: Routes.live_dashboard_path(@conn, :home),
       conn: @conn

--- a/lib/turbo_web/templates/layout/admin/menu_item.html.heex
+++ b/lib/turbo_web/templates/layout/admin/menu_item.html.heex
@@ -2,6 +2,6 @@
   <%= link(@text,
     to: @path,
     class:
-      "block hover:underline p-2 my-2 rounded font-bold #{@conn.request_path == @path && "bg-slate-100"}"
+      "block hover:underline p-2 my-2 rounded font-bold #{@conn.request_path == @path && "bg-slate-200"}"
   ) %>
 </li>

--- a/lib/turbo_web/templates/layout/header.html.heex
+++ b/lib/turbo_web/templates/layout/header.html.heex
@@ -42,5 +42,10 @@
         </li>
       <% end %>
     </ul>
+    <%= if @current_user do %>
+      <p class="block mt-2 text-xs text-right text-slate-500">
+        Hi, <%= @current_user.email %> <span aria-hidden="true">👋</span>
+      </p>
+    <% end %>
   </nav>
 </header>

--- a/lib/turbo_web/views/admin/user_management_view.ex
+++ b/lib/turbo_web/views/admin/user_management_view.ex
@@ -1,0 +1,3 @@
+defmodule TurboWeb.Admin.UserManagementView do
+  use TurboWeb, :view
+end

--- a/priv/repo/migrations/20221009200100_add_user_lock.exs
+++ b/priv/repo/migrations/20221009200100_add_user_lock.exs
@@ -1,0 +1,15 @@
+defmodule Turbo.Repo.Migrations.AddUserLock do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      add :is_locked, :boolean, null: false, default: false
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      remove :is_locked
+    end
+  end
+end

--- a/test/turbo/accounts_test.exs
+++ b/test/turbo/accounts_test.exs
@@ -517,6 +517,21 @@ defmodule Turbo.AccountsTest do
     end
   end
 
+  describe "toggle_access/1" do
+    test "should lock a user that previously had access to the system" do
+      common_user = user_fixture()
+      {:ok, locked_user} = Accounts.toggle_access(common_user.id)
+      assert locked_user.is_locked
+    end
+
+    test "should unlock a user that previously had no access to the system" do
+      common_user = user_fixture()
+      {:ok, locked_user} = Accounts.toggle_access(common_user.id)
+      {:ok, unlocked_user} = Accounts.toggle_access(locked_user.id)
+      refute unlocked_user.is_locked
+    end
+  end
+
   describe "inspect/2" do
     test "does not include password" do
       refute inspect(%User{password: "123456"}) =~ "password: \"123456\""

--- a/test/turbo_web/controllers/admin/user_management_controller_test.exs
+++ b/test/turbo_web/controllers/admin/user_management_controller_test.exs
@@ -1,0 +1,48 @@
+defmodule TurboWeb.Controllers.Admin.UserManagementControllerTest do
+  use TurboWeb.ConnCase
+  import Turbo.AccountsFixtures
+
+  setup :register_and_log_in_admin
+
+  describe "GET /admin/settings/users" do
+    test "redirects if user is not logged in" do
+      conn = build_conn()
+      conn = get(conn, Routes.user_management_path(conn, :index))
+      assert redirected_to(conn) == Routes.user_session_path(conn, :new)
+    end
+
+    test "renders Users page for admin users", %{conn: conn} do
+      conn = get(conn, Routes.user_management_path(conn, :index))
+      user = conn.assigns[:current_user]
+      response = html_response(conn, 200)
+      assert response =~ user.email
+      assert response =~ "Update role"
+    end
+  end
+
+  describe "POST /admin/users/access (user access form)" do
+    test "manage user login access", %{conn: conn} do
+      common_user = user_fixture()
+
+      user_access_conn =
+        post(conn, Routes.user_management_path(conn, :toggle_access), %{
+          "user_id" => common_user.id
+        })
+
+      assert redirected_to(user_access_conn) ==
+               Routes.user_management_path(user_access_conn, :index)
+
+      assert get_flash(user_access_conn, :info) =~ "#{common_user.email} access revoked."
+
+      user_access_conn =
+        post(conn, Routes.user_management_path(conn, :toggle_access), %{
+          "user_id" => common_user.id
+        })
+
+      assert redirected_to(user_access_conn) ==
+               Routes.user_management_path(user_access_conn, :index)
+
+      assert get_flash(user_access_conn, :info) =~ "#{common_user.email} access granted."
+    end
+  end
+end

--- a/test/turbo_web/controllers/admin/user_management_controller_test.exs
+++ b/test/turbo_web/controllers/admin/user_management_controller_test.exs
@@ -58,4 +58,33 @@ defmodule TurboWeb.Controllers.Admin.UserManagementControllerTest do
                "To avoid lockouts, you cannot update your own account. Please contact another admin."
     end
   end
+
+  describe "POST /admin/users/role (user role form)" do
+    test "update user role", %{conn: conn} do
+      common_user = user_fixture()
+
+      user_role_conn =
+        post(conn, Routes.user_management_path(conn, :update_role), %{
+          "user_id" => common_user.id,
+          "role" => "admin"
+        })
+
+      assert redirected_to(user_role_conn) == Routes.user_management_path(user_role_conn, :index)
+
+      assert get_flash(user_role_conn, :info) =~ "#{common_user.email} role updated."
+    end
+
+    test "cannot change its own role as an admin", %{conn: conn, user: admin} do
+      user_role_conn =
+        post(conn, Routes.user_management_path(conn, :update_role), %{
+          "user_id" => admin.id,
+          "role" => "user"
+        })
+
+      assert redirected_to(user_role_conn) == Routes.user_management_path(user_role_conn, :index)
+
+      assert get_flash(user_role_conn, :error) =~
+               "To avoid lockouts, you cannot update your own account. Please contact another admin."
+    end
+  end
 end

--- a/test/turbo_web/controllers/admin/user_management_controller_test.exs
+++ b/test/turbo_web/controllers/admin/user_management_controller_test.exs
@@ -44,5 +44,18 @@ defmodule TurboWeb.Controllers.Admin.UserManagementControllerTest do
 
       assert get_flash(user_access_conn, :info) =~ "#{common_user.email} access granted."
     end
+
+    test "cannot lock its own admin account", %{conn: conn, user: admin} do
+      user_access_conn =
+        post(conn, Routes.user_management_path(conn, :toggle_access), %{
+          "user_id" => admin.id
+        })
+
+      assert redirected_to(user_access_conn) ==
+               Routes.user_management_path(user_access_conn, :index)
+
+      assert get_flash(user_access_conn, :error) =~
+               "To avoid lockouts, you cannot update your own account. Please contact another admin."
+    end
   end
 end


### PR DESCRIPTION
## Features

- [x] Lock user accounts so they can't login anymore
- [x] Change system role (between `user` and `admin`)

### Admin settings screenshot
<img width="1299" alt="Screenshot 2022-10-15 at 13 26 11" src="https://user-images.githubusercontent.com/2049560/195984308-06ab7094-11bb-4a8e-9c90-282903e7c487.png">
