### PR TITLE
feat: allow db cert specification

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -53,6 +53,12 @@ if config_env() == :prod do
 
   config :turbo, Turbo.Repo,
     ssl: use_db_ssl,
+    ssl_opts: [
+      verify: :verify_peer,
+      cacertfile: System.get_env("DATABASE_CA_CERT"),
+      verify_fun: &:ssl_verify_hostname.verify_fun/3,
+      server_name_indication: String.to_charlist(System.get_env("DATABASE_HOST", "")),
+    ],
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,6 @@ services:
       - "4000:4000"
     volumes:
       - ./docker_turbo_artifacts:/var/turbo_artifacts
-
   turbo_racer_db:
     image: postgres:14.2
     container_name: turbo_racer_db


### PR DESCRIPTION
Hey @brunojppb,

thanks for putting this project togehter - super cool!

Digital Ocean Databases for example are per default exposed with self signed certificates. It would be really handy to allow those to be configured.

I have pretty much no Idea what Im doing, but got some inspiration [here](https://github.com/elixir-ecto/postgrex/issues/463#issuecomment-647454607)